### PR TITLE
Update menu.html to include the check icon

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -105,7 +105,7 @@
       <a href="{{.RelPermalink}}">
           {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
           {{ if $showvisitedlinks}}
-            <i class="fas read-icon"></i>
+            <i class="fas fa-check read-icon"></i>
           {{ end }}
       </a>
       {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}


### PR DESCRIPTION
I'm seeing issues where the check icon is not rendered. It seems like it this `<i></i>` element was mistakenly missing the additional class required in order for it to actually render the font-awesome check icon. So, I added the `fa-check` class locally and now it works as expected.